### PR TITLE
Include type and layout in patch.objects list

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,7 +153,7 @@ var Pd = module.exports = {
         obj.setData(new Float32Array(arrayNodeData.data), true)
         proto = 'array'
       } else {
-        obj = patch._createObject(proto, nodeData.args || [])
+        obj = patch._createObject(proto, nodeData.args || [], nodeData.layout)
       }
       if (proto === 'pd') Pd._preparePatch(obj, nodeData.subpatch)
       createdObjs[nodeData.id] = obj

--- a/lib/core/Patch.js
+++ b/lib/core/Patch.js
@@ -79,8 +79,8 @@ _.extend(Patch.prototype, BaseNode.prototype, utils.UniqueIdsMixin, EventEmitter
   // Also causes the patch to automatically assign an id to that object.
   // This id can be used to uniquely identify the object in the patch.
   // Also, if the patch is playing, the `start` method of the object will be called.
-  createObject: function(type, objArgs) {
-    var obj = this._createObject(type, objArgs)
+  createObject: function(type, objArgs, layout) {
+    var obj = this._createObject(type, objArgs, layout)
     if (pdGlob.isStarted) {
       obj.start()
       obj.startPortlets()
@@ -88,7 +88,7 @@ _.extend(Patch.prototype, BaseNode.prototype, utils.UniqueIdsMixin, EventEmitter
     return obj
   },
 
-  _createObject: function(type, objArgs) {
+  _createObject: function(type, objArgs, layout) {
     var obj
     objArgs = objArgs || []
 
@@ -98,6 +98,8 @@ _.extend(Patch.prototype, BaseNode.prototype, utils.UniqueIdsMixin, EventEmitter
       if (constructor.prototype.doResolveArgs)
         objArgs = this.resolveArgs(objArgs)
       obj = new constructor(this, this._generateId(), objArgs)
+      obj["type"] = type;
+      obj["layout"] = layout
     } else throw new Error('unknown object ' + type)
 
     // Assign object unique id and add it to the patch


### PR DESCRIPTION
Hi Sebastién, amazing work. 

I added code to include object type and layout information within the patch.objects list. It's a minor addition, not sure if useful in the core project, but it might help someone else who also wants to programmatically generate a UI from the patch.objects list.

Cheers!