### PR TITLE
Mention node's http-server utility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ For security reasons, browsers control access to your file system from web pages
 
 Python comes bundled with such a web server. Open a terminal, navigate to the folder containing the web page you want to open, then run `python -m SimpleHTTPServer` if you are using **Python 2** or `python -m http.server` if you are using **Python 3**. Then open your web browser to [http://localhost:8000](http://localhost:8000) and things should start working.
 
+Alternatively, if you prefer node, you may want to install the handy [`http-server`](https://github.com/indexzero/http-server#readme) command-line utility.
 
 ### Other patches have worked before but this one doesn't
 


### PR DESCRIPTION
Since Windows users in particular may not have Python pre-installed on their system, and since WebPd uses node for everything, I thought it might be worth mentioning the handy [`http-server`](https://www.npmjs.com/package/http-server) utility as an alternative to Python's HTTP server (which is also slightly buggy in my experience anyways).

If you feel this just clutters your README, no worries, feel free to close this PR!