### PR TITLE
fix: correct Unkown→Unknown typo in CLI error message

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -274,7 +274,7 @@ const exitError = (msg: string) => {
 
 const exitUnknownError = (err: Error) => {
     exitError(
-        'Unkown error occurred.' +
+        'Unknown error occurred.' +
             '\nIf you think this is a bug, please report it with the command you typed and its output.' +
             '\nPlease follow also the guidelines at https://github.com/sebpiq/WebPd/?tab=readme-ov-file#reporting-a-bug' +
             '\n\n' +


### PR DESCRIPTION
## Summary
Fixes typo in CLI error message: `Unkown error occurred.` → `Unknown error occurred.`

## Change
- `src/cli/main.ts` line 277: `Unkown` → `Unknown`

## Testing
No functional change — string correction only. CLI behavior unchanged.